### PR TITLE
Use rational powers only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Powers are now rational numbers and not floating point values.
+
 ### Added
 
 - New coherent unit `scalar` that can be used in binary operations with units.
 - New constructor `Coherent_unit(TU_TYPE)` so that a coherent unit can be created with value.
+- New prefixes `quecto`, `ronto`, `ronna`, `quetta`.
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(TU VERSION 0.1.0 LANGUAGES CXX)
+project(TU VERSION 0.2.0 LANGUAGES CXX)
 
 enable_testing()
 add_subdirectory(typesafe_units)

--- a/TUConfigVersion.cmake
+++ b/TUConfigVersion.cmake
@@ -9,16 +9,52 @@
 # The variable CVF_VERSION must be set before calling configure_file().
 
 
-set(PACKAGE_VERSION "0.1.0")
-
-if("0.1.0" MATCHES "^([0-9]+\\.[0-9]+\\.[0-9]+)\\.") # strip the tweak version
-  set(CVF_VERSION_NO_TWEAK "${CMAKE_MATCH_1}")
-else()
-  set(CVF_VERSION_NO_TWEAK "0.1.0")
+if (PACKAGE_FIND_VERSION_RANGE)
+  message(AUTHOR_WARNING
+    "`find_package()` specify a version range but the version strategy "
+    "(ExactVersion) of the module `${PACKAGE_FIND_NAME}` is incompatible "
+    "with this request. Only the lower endpoint of the range will be used.")
 endif()
 
-if(PACKAGE_FIND_VERSION MATCHES "^([0-9]+\\.[0-9]+\\.[0-9]+)\\.") # strip the tweak version
-  set(REQUESTED_VERSION_NO_TWEAK "${CMAKE_MATCH_1}")
+set(PACKAGE_VERSION "0.2.0")
+
+if("0.2.0" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)") # strip the tweak version
+  set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  set(CVF_VERSION_MINOR "${CMAKE_MATCH_2}")
+  set(CVF_VERSION_PATCH "${CMAKE_MATCH_3}")
+
+  if(NOT CVF_VERSION_MAJOR VERSION_EQUAL 0)
+    string(REGEX REPLACE "^0+" "" CVF_VERSION_MAJOR "${CVF_VERSION_MAJOR}")
+  endif()
+  if(NOT CVF_VERSION_MINOR VERSION_EQUAL 0)
+    string(REGEX REPLACE "^0+" "" CVF_VERSION_MINOR "${CVF_VERSION_MINOR}")
+  endif()
+  if(NOT CVF_VERSION_PATCH VERSION_EQUAL 0)
+    string(REGEX REPLACE "^0+" "" CVF_VERSION_PATCH "${CVF_VERSION_PATCH}")
+  endif()
+
+  set(CVF_VERSION_NO_TWEAK "${CVF_VERSION_MAJOR}.${CVF_VERSION_MINOR}.${CVF_VERSION_PATCH}")
+else()
+  set(CVF_VERSION_NO_TWEAK "0.2.0")
+endif()
+
+if(PACKAGE_FIND_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)") # strip the tweak version
+  set(REQUESTED_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  set(REQUESTED_VERSION_MINOR "${CMAKE_MATCH_2}")
+  set(REQUESTED_VERSION_PATCH "${CMAKE_MATCH_3}")
+
+  if(NOT REQUESTED_VERSION_MAJOR VERSION_EQUAL 0)
+    string(REGEX REPLACE "^0+" "" REQUESTED_VERSION_MAJOR "${REQUESTED_VERSION_MAJOR}")
+  endif()
+  if(NOT REQUESTED_VERSION_MINOR VERSION_EQUAL 0)
+    string(REGEX REPLACE "^0+" "" REQUESTED_VERSION_MINOR "${REQUESTED_VERSION_MINOR}")
+  endif()
+  if(NOT REQUESTED_VERSION_PATCH VERSION_EQUAL 0)
+    string(REGEX REPLACE "^0+" "" REQUESTED_VERSION_PATCH "${REQUESTED_VERSION_PATCH}")
+  endif()
+
+  set(REQUESTED_VERSION_NO_TWEAK
+      "${REQUESTED_VERSION_MAJOR}.${REQUESTED_VERSION_MINOR}.${REQUESTED_VERSION_PATCH}")
 else()
   set(REQUESTED_VERSION_NO_TWEAK "${PACKAGE_FIND_VERSION}")
 endif()
@@ -33,11 +69,6 @@ if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
   set(PACKAGE_VERSION_EXACT TRUE)
 endif()
 
-
-# if the installed project requested no architecture check, don't perform the check
-if("FALSE")
-  return()
-endif()
 
 # if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
 if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "8" STREQUAL "")

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -340,8 +340,6 @@ int main() {
 
         Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> s12 = s1 - s2; 
         t.template assert<near<>>(-(TU_TYPE)10.0e-3f, s12.base_value, __LINE__);
-
-        auto s3 = s12 + s12;
       }
     );
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -169,18 +169,26 @@ int main() {
     }
   );
 
+  Test<"is_ratio">(
+    []<typename T>(T &t) {
+      t.assert_true(is_ratio<std::ratio<1,2>>::value, __LINE__);
+      t.assert_false(is_ratio<int>::value, __LINE__);
+      t.assert_true(is_ratio_v<std::ratio<1,2>>, __LINE__);
+      t.assert_false(is_ratio_v<int>, __LINE__);
+    }
+  );
+
   Test<"Coherent_unit_base">(
     []<typename T>(T &t) {
       TU_TYPE val = 3.5;
-
-      auto c1 = Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)2.0>(val);
+      auto c1 = Coherent_unit_base<std::ratio<1>, std::ratio<2>>(val);
       t.template assert<std::equal_to<>>(val, c1.base_value, __LINE__);
           
-      auto c2 = Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)2.0>(c1);
+      auto c2 = Coherent_unit_base<std::ratio<1>, std::ratio<2>>(c1);
       t.template assert<std::equal_to<>>(val, c2.base_value , __LINE__);
 
       Unit<prefix::milli, degree_Fahrenheit> f(val);
-      Coherent_unit_base<(TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0> c3 = Coherent_unit_base(f);
+      Coherent_unit_base<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>> c3 = Coherent_unit_base(f);
       t.template assert<near<>>((val * 1.0e-3f - (TU_TYPE)32.0)/1.8f + (TU_TYPE)273.15, c3.base_value , __LINE__);
     }       
   );
@@ -212,9 +220,9 @@ int main() {
 
   Test<"create_coherent_unit">(
     []<typename T>(T &t){
-      Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)2.0, (TU_TYPE)3.0, (TU_TYPE)4.0, (TU_TYPE)5.0, (TU_TYPE)6.0, (TU_TYPE)7.0> cub;
+      Coherent_unit_base<std::ratio<-1>, std::ratio<2>, std::ratio<3>, std::ratio<4>, std::ratio<5>, std::ratio<6>, std::ratio<7>> cub;
       auto cu = internal::create_coherent_unit(cub);
-      t.assert_true(std::is_same<decltype(cu), Coherent_unit<s<(TU_TYPE)1.0>, m<(TU_TYPE)2.0>, kg<(TU_TYPE)3.0>, A<(TU_TYPE)4.0>, K<(TU_TYPE)5.0>, mol<(TU_TYPE)6.0>, cd<(TU_TYPE)7.0>>>::value, __LINE__);
+      t.assert_true(std::is_same<decltype(cu), Coherent_unit<s<std::ratio<-1>>, m<std::ratio<2>>, kg<std::ratio<3>>, A<std::ratio<4>>, K<std::ratio<5>>, mol<std::ratio<6>>, cd<std::ratio<7>>>>::value, __LINE__);
     }
   );
 
@@ -223,6 +231,9 @@ int main() {
         TU_TYPE value = (TU_TYPE)5.0f;
         Unit<prefix::no_prefix, second> s(value);
         t.template assert<std::equal_to<>>(s.value, value, __LINE__);
+
+        //SUnit<second> ss(value);
+        //t.template assert<std::equal_to<>>(ss.value, value, __LINE__);
 
         Unit<prefix::no_prefix, second> s2 = value;
         t.template assert<std::equal_to<>>(s2.value, value, __LINE__); 
@@ -246,11 +257,11 @@ int main() {
     Test<"is_scalar">(
       []<typename T>(T &t){
         TU_TYPE val = 0.0;
-        auto not_scalar = Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)2.0>(val);
-        auto not_scalar2 = Coherent_unit_base<(TU_TYPE)0.0, (TU_TYPE)2.0>(val);
-        auto not_scalar3 = Coherent_unit_base<(TU_TYPE)1.0>(val);
-        auto scalar = Coherent_unit_base<(TU_TYPE)0.0, (TU_TYPE)0.0>(val);
-        auto scalar2 = Coherent_unit_base<(TU_TYPE)0.0>(val);
+        auto not_scalar = Coherent_unit_base<std::ratio<1>, std::ratio<2>>(val);
+        auto not_scalar2 = Coherent_unit_base<std::ratio<0>, std::ratio<2>>(val);
+        auto not_scalar3 = Coherent_unit_base<std::ratio<1>>(val);
+        auto scalar = Coherent_unit_base<std::ratio<0>, std::ratio<0>>(val);
+        auto scalar2 = Coherent_unit_base<std::ratio<0>>(val);
 
         t.assert_false(not_scalar.is_scalar(), __LINE__);
         t.assert_false(not_scalar2.is_scalar(), __LINE__);
@@ -289,8 +300,8 @@ int main() {
         auto value2 = 20000.0f;
         //Unit<prefix::milli, second> s1(value1);
         //Unit<prefix::micro, second> s2(value2);
-        Coherent_unit<s<(TU_TYPE)1.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> s1(value1);
-        Coherent_unit<s<(TU_TYPE)1.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> s2(value2);
+        Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> s1(value1);
+        Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> s2(value2);
 
         t.assert_true(s1 < s2, __LINE__);
         t.assert_false(s1 >= s2, __LINE__);
@@ -315,7 +326,7 @@ int main() {
         Unit<prefix::milli, second> s1(value1);
         Unit<prefix::micro, second> s2(value2);
 
-        Coherent_unit<s<(TU_TYPE)1.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> s12 = s1 + s2;
+        Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> s12 = s1 + s2;
         t.template assert<near<>>((TU_TYPE)30.0e-3f, s12.base_value, __LINE__);
       }
     );
@@ -327,7 +338,7 @@ int main() {
         Unit<prefix::milli, second> s1(value1);
         Unit<prefix::micro, second> s2(value2);
 
-        Coherent_unit<s<(TU_TYPE)1.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> s12 = s1 - s2; 
+        Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> s12 = s1 - s2; 
         t.template assert<near<>>(-(TU_TYPE)10.0e-3f, s12.base_value, __LINE__);
 
         auto s3 = s12 + s12;
@@ -340,7 +351,7 @@ int main() {
         TU_TYPE value2 = 20.0;
         Unit<prefix::milli, second> s1(value1);
         Unit<prefix::milli, ampere> a1(value2);
-        Coherent_unit<s<(TU_TYPE)1.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)1.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> sa = s1 * a1;
+        Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> sa = s1 * a1;
         t.template assert<near<>>(sa.base_value, value1 * value2 * (TU_TYPE)1.0e-6f, __LINE__);
       }
     );
@@ -352,7 +363,7 @@ int main() {
         Unit<prefix::milli, second> s1(value1);
         Unit<prefix::milli, ampere> a1(value2);
 
-        Coherent_unit<s<(TU_TYPE)1.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)-1.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> sa = s1 / a1;
+        Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<-1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> sa = s1 / a1;
         t.template assert<std::equal_to<>>(sa.base_value, value1 / value2, __LINE__);
       }
     );
@@ -361,16 +372,16 @@ int main() {
       []<typename T>(T &t){
         TU_TYPE value1 = 10.0;
         TU_TYPE value2 = 20.0;
-        Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0> s1(value1);
-        Coherent_unit_base<(TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0> a1(value2);
+        Coherent_unit_base<std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>> s1(value1);
+        Coherent_unit_base<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<0>> a1(value2);
 
-        Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0> sa = s1 * a1;
+        Coherent_unit_base<std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<0>> sa = s1 * a1;
         t.template assert<std::equal_to<>>(sa.base_value, value1 * value2, __LINE__);
       
         auto s2 = internal::create_coherent_unit(s1);
         auto a2 = internal::create_coherent_unit(a1);
 
-        Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0> sa2 = s2 * a2;
+        Coherent_unit_base<std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<0>> sa2 = s2 * a2;
         t.template assert<std::equal_to<>>(sa2.base_value, value1 * value2, __LINE__);
       }
     );
@@ -379,66 +390,106 @@ int main() {
       []<typename T>(T &t){
         auto value1 = (TU_TYPE)10.0f;
         auto value2 = (TU_TYPE)20.0f;
-        Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0> s1(value1);
-        Coherent_unit_base<(TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0> a1(value2);
+        Coherent_unit_base<std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>> s1(value1);
+        Coherent_unit_base<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<0>> a1(value2);
 
-        Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)-1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0> sa = s1 / a1;
+        Coherent_unit_base<std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<-1>, std::ratio<0>, std::ratio<0>, std::ratio<0>> sa = s1 / a1;
         t.template assert<std::equal_to<>>(sa.base_value, value1 / value2, __LINE__);
       
         auto s2 = internal::create_coherent_unit(s1);
         auto a2 = internal::create_coherent_unit(a1);
 
-        Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)-1.0, (TU_TYPE)0.0, (TU_TYPE)0.0, (TU_TYPE)0.0> sa2 = s2 / a2;
+        Coherent_unit_base<std::ratio<1>, std::ratio<0>, std::ratio<0>, std::ratio<-1>, std::ratio<0>, std::ratio<0>, std::ratio<0>> sa2 = s2 / a2;
         t.template assert<std::equal_to<>>(sa2.base_value, value1 / value2, __LINE__);
+      }
+    );
+
+    Test<"Coherent_unit and Coherent_unit_base binary operator: +">(
+      []<typename T>(T &t){
+        auto value1 = (TU_TYPE)10.0f;
+        auto value2 = (TU_TYPE)20.0f;
+        Coherent_unit_base<std::ratio<-1>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>> s1(value1);
+        Coherent_unit_base<std::ratio<-1>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>> a1(value2);
+
+        Coherent_unit_base<std::ratio<-1>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>> sa = s1 + a1;
+        t.template assert<std::equal_to<>>(sa.base_value, value1 + value2, __LINE__);
+      
+        auto s2 = internal::create_coherent_unit(s1);
+        auto a2 = internal::create_coherent_unit(a1);
+
+        Coherent_unit<s<std::ratio<-1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> sa2 = s2 + a2;
+        t.template assert<std::equal_to<>>(sa2.base_value, value1 + value2, __LINE__);
+      }
+    );
+
+    Test<"Coherent_unit and Coherent_unit_base binary operator: -">(
+      []<typename T>(T &t){
+        auto value1 = (TU_TYPE)10.0f;
+        auto value2 = (TU_TYPE)20.0f;
+        Coherent_unit_base<std::ratio<-1>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>> s1(value1);
+        Coherent_unit_base<std::ratio<-1>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>> a1(value2);
+
+        Coherent_unit_base<std::ratio<-1>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>> sa = s1 - a1;
+        t.template assert<std::equal_to<>>(sa.base_value, value1 - value2, __LINE__);
+      
+        auto s2 = internal::create_coherent_unit(s1);
+        auto a2 = internal::create_coherent_unit(a1);
+
+        Coherent_unit<s<std::ratio<-1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> sa2 = s2 - a2;
+        t.template assert<std::equal_to<>>(sa2.base_value, value1 - value2, __LINE__);
       }
     );
 
     Test<"binary_op_args">(
       []<typename T>(T ){
         {
-          Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)2.0, (TU_TYPE)3.0, (TU_TYPE)4.0, (TU_TYPE)5.0, (TU_TYPE)6.0, (TU_TYPE)7.0> l(2);
-          Coherent_unit_base<(TU_TYPE)6.0, (TU_TYPE)5.0, (TU_TYPE)4.0, (TU_TYPE)3.0, (TU_TYPE)2.0, (TU_TYPE)1.0, (TU_TYPE)0.0> r(3);
+          Coherent_unit_base<std::ratio<1>, std::ratio<2>, std::ratio<3>, std::ratio<4>, std::ratio<5>, std::ratio<6>, std::ratio<7>> l(2);
+          Coherent_unit_base<std::ratio<6>, std::ratio<5>, std::ratio<4>, std::ratio<3>, std::ratio<2>, std::ratio<1>, std::ratio<0>> r(3);
           Coherent_unit_base<> lr;
-          Coherent_unit_base<(TU_TYPE)7.0, (TU_TYPE)7.0, (TU_TYPE)7.0, (TU_TYPE)7.0, (TU_TYPE)7.0, (TU_TYPE)7.0, (TU_TYPE)7.0> l_plus_r = binary_op_args(l, r, lr, std::plus<TU_TYPE>());
-          Coherent_unit<s<(TU_TYPE)7.0>, m<(TU_TYPE)7.0>, kg<(TU_TYPE)7.0>, A<(TU_TYPE)7.0>, K<(TU_TYPE)7.0>, mol<(TU_TYPE)7.0>, cd<(TU_TYPE)7.0>> l_plus_r_c = binary_op_args(l, r, lr, std::plus<TU_TYPE>());
+          Coherent_unit_base<std::ratio<7>, std::ratio<7>, std::ratio<7>, std::ratio<7>, std::ratio<7>, std::ratio<7>, std::ratio<7>> l_plus_r = binary_op_args(l, r, lr, Plus());
+          Coherent_unit<s<std::ratio<7>>, m<std::ratio<7>>, kg<std::ratio<7>>, A<std::ratio<7>>, K<std::ratio<7>>, mol<std::ratio<7>>, cd<std::ratio<7>>> l_plus_r_c = binary_op_args(l, r, lr, Plus());
         }
     }
   );
 
   Test<"binary_op_args_num">(
     []<typename T>(T ) {
-      Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)2.0, (TU_TYPE)3.0, (TU_TYPE)4.0, (TU_TYPE)5.0, (TU_TYPE)6.0, (TU_TYPE)7.0> l;
+      Coherent_unit_base<std::ratio<1>, std::ratio<2>, std::ratio<3>, std::ratio<4>, std::ratio<5>, std::ratio<6>, std::ratio<7>> l;
       Coherent_unit_base<> empty;
-      Coherent_unit_base<(TU_TYPE)2.0, (TU_TYPE)4.0, (TU_TYPE)6.0, (TU_TYPE)8.0, (TU_TYPE)10.0, (TU_TYPE)12.0, (TU_TYPE)14.0> r = binary_op_args_num(l, powexp<(TU_TYPE)2.0>(), empty, std::multiplies<TU_TYPE>());
-      Coherent_unit<s<(TU_TYPE)2.0>, m<(TU_TYPE)4.0>, kg<(TU_TYPE)6.0>, A<(TU_TYPE)8.0>, K<(TU_TYPE)10.0>, mol<(TU_TYPE)12.0>, cd<(TU_TYPE)14.0>> r2 = binary_op_args_num(l, powexp<(TU_TYPE)2.0>(), empty, std::multiplies<TU_TYPE>());
+      Coherent_unit_base<std::ratio<2>, std::ratio<4>, std::ratio<6>, std::ratio<8>, std::ratio<10>, std::ratio<12>, std::ratio<14>> r = binary_op_args_num(l, std::ratio<2>(), empty, Multiply());
+      Coherent_unit<s<std::ratio<2>>, m<std::ratio<4>>, kg<std::ratio<6>>, A<std::ratio<8>>, K<std::ratio<10>>, mol<std::ratio<12>>, cd<std::ratio<14>>> r2 = binary_op_args_num(l, std::ratio<2>(), empty, Multiply());
     }
   );
 
   Test<"pow Coherent_unit_base">(
     []<typename T>(T &t) {
       TU_TYPE value = 3.0;
-      Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)2.0, (TU_TYPE)3.0, (TU_TYPE)4.0, (TU_TYPE)5.0, (TU_TYPE)6.0, (TU_TYPE)7.0> r(value);
-      Coherent_unit_base<(TU_TYPE)2.0, (TU_TYPE)4.0, (TU_TYPE)6.0, (TU_TYPE)8.0, (TU_TYPE)10.0, (TU_TYPE)12.0, (TU_TYPE)14.0> l = pow<(TU_TYPE)2.0>(r);
+      Coherent_unit_base<std::ratio<1>, std::ratio<2>, std::ratio<3>, std::ratio<4>, std::ratio<5>, std::ratio<6>, std::ratio<7>> r(value);
+      Coherent_unit_base<std::ratio<2>, std::ratio<4>, std::ratio<6>, std::ratio<8>, std::ratio<10>, std::ratio<12>, std::ratio<14>> l = pow<std::ratio<2>>(r);
       t.template assert<std::equal_to<>>((TU_TYPE)pow(value, (TU_TYPE)2.0f), l.base_value, __LINE__);
 
-      Coherent_unit<s<(TU_TYPE)2.0>, m<(TU_TYPE)4.0>, kg<(TU_TYPE)6.0>, A<(TU_TYPE)8.0>, K<(TU_TYPE)10.0>, mol<(TU_TYPE)12.0>, cd<(TU_TYPE)14.0>> a = pow<(TU_TYPE)2.0>(r);
+      Coherent_unit<s<std::ratio<2>>, m<std::ratio<4>>, kg<std::ratio<6>>, A<std::ratio<8>>, K<std::ratio<10>>, mol<std::ratio<12>>, cd<std::ratio<14>>> a = pow<std::ratio<2>>(r);
     }
   );
 
-    Test<"pow Unit">(
+  Test<"pow Unit">(
     []<typename T>(T &t) {
       TU_TYPE value1 = (TU_TYPE)20.0f;
+      Unit<prefix::milli, hertz> h1(value1);
       Unit<prefix::milli, second> s1(value1);
-      Coherent_unit<s<(TU_TYPE)2.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> l = pow<(TU_TYPE)2.0>(s1);
-      t.template assert<near<>>(l.base_value, (TU_TYPE)pow(value1, (TU_TYPE)2.0) * (TU_TYPE)1.0e-6f, __LINE__);
+      Coherent_unit<s<std::ratio<2>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> l1 = pow<std::ratio<2>>(s1);
+      t.template assert<near<>>(l1.base_value, (TU_TYPE)pow(value1, (TU_TYPE)2.0) * (TU_TYPE)1.0e-6f, __LINE__);
+    
+      Coherent_unit<s<std::ratio<-2>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> l2 = pow<std::ratio<2>>(h1);
+      t.template assert<near<>>(l2.base_value, (TU_TYPE)pow(value1, (TU_TYPE)2.0) * (TU_TYPE)1.0e-6f, __LINE__);
     }
   );
 
     Test<"sqrt Coherent_unit_base">(
     []<typename T>(T &t) {
       TU_TYPE value = 4.0;
-      Coherent_unit_base<(TU_TYPE)2.0, (TU_TYPE)4.0, (TU_TYPE)6.0, (TU_TYPE)8.0, (TU_TYPE)10.0, (TU_TYPE)12.0, (TU_TYPE)14.0> r(value);
-      Coherent_unit_base<(TU_TYPE)1.0, (TU_TYPE)2.0, (TU_TYPE)3.0, (TU_TYPE)4.0, (TU_TYPE)5.0, (TU_TYPE)6.0, (TU_TYPE)7.0> l = sqrt(r);
+      Coherent_unit_base<std::ratio<2>, std::ratio<4>, std::ratio<6>, std::ratio<8>, std::ratio<10>, std::ratio<12>, std::ratio<14>> r(value);
+      Coherent_unit_base<std::ratio<1>, std::ratio<2>, std::ratio<3>, std::ratio<4>, std::ratio<5>, std::ratio<6>, std::ratio<7>> l = sqrt(r);
       t.template assert<std::equal_to<>>(std::sqrt(value), l.base_value, __LINE__);
     }
   );
@@ -447,7 +498,7 @@ int main() {
     []<typename T>(T &t) {
       TU_TYPE value1 = 20.0;
       Unit<prefix::milli, second> s1(value1);
-      Coherent_unit<s<(TU_TYPE)0.5>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> l =  sqrt(s1);
+      Coherent_unit<s<std::ratio<1,2>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> l =  sqrt(s1);
       t.template assert<near<>>(l.base_value, std::sqrt(value1) * std::pow((TU_TYPE)1e-3, (TU_TYPE)0.5), __LINE__);
     }
   );
@@ -455,12 +506,12 @@ int main() {
   Test<"unop Coherent_unit_base">(
     []<typename T>(T &t) {
       TU_TYPE val = 0.0;
-      auto scalar2 = Coherent_unit_base<(TU_TYPE)0.0>((TU_TYPE)tu::PI/2.0);
-      auto scalar = Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>>();
+      auto scalar2 = Coherent_unit_base<std::ratio<0>>((TU_TYPE)tu::PI/2.0);
+      auto scalar = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>();
       t.template assert<near<>>(unop<std::sin>(scalar).base_value, (TU_TYPE)0.0, __LINE__);
       t.template assert<near<>>(unop<std::sin>(scalar2).base_value, (TU_TYPE)1.0, __LINE__);
       
-      Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> scalar3 = unop<std::sin>(scalar);
+      Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> scalar3 = unop<std::sin>(scalar);
 
       // lambda is globally defined to compile with gcc 
       auto new_scalar_2 = unop<lambda>(scalar);
@@ -478,7 +529,7 @@ int main() {
        
       Unit<prefix::no_prefix, degree> new_scalar_unit = unop<std::sin>(scalar_unit);
 
-      Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>> scalar3 = unop<std::sin>(scalar_unit);
+      Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>> scalar3 = unop<std::sin>(scalar_unit);
 
       t.template assert<near<>>(unop<std::sin>(scalar_unit).base_value, (TU_TYPE)1.0, __LINE__);
       t.template assert<near<>>(unop<std::sin>(scalar_unit2).base_value, (TU_TYPE)0.0, __LINE__);
@@ -504,30 +555,15 @@ int main() {
          }
   );
 
-  Test<"powexp">(
-    []<typename T>(T) {
-           static_assert(powexp<(TU_TYPE)-2.0>::exp == -2);
-           static_assert(powexp<(TU_TYPE)-1.0>::exp == -1);
-           static_assert(powexp<(TU_TYPE)0.0>::exp == 0);
-           static_assert(powexp<(TU_TYPE)1.0>::exp == 1);
-           static_assert(powexp<(TU_TYPE)2.0>::exp == 2);       
-           static_assert(powexp<(TU_TYPE)-2.0>::exp != 1);
-           static_assert(powexp<(TU_TYPE)-1.0>::exp != 1);
-           static_assert(powexp<(TU_TYPE)0.0>::exp != 1);
-           static_assert(powexp<(TU_TYPE)1.0>::exp != 0);
-           static_assert(powexp<(TU_TYPE)2.0>::exp != 1);
-         }
-  );
-
   Test<"Coherent units definition">(
     []<typename T>(T) {
-           static_assert(std::is_base_of<Coherent_unit<s<(TU_TYPE)1.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>>, second>::value);
-           static_assert(std::is_base_of<Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)1.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>>, metre>::value);
-           static_assert(std::is_base_of<Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)1.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>>, kilogram>::value);
-           static_assert(std::is_base_of<Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)1.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>>, ampere>::value);
-           static_assert(std::is_base_of<Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)1.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)0.0>>, kelvin>::value);
-           static_assert(std::is_base_of<Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)1.0>, cd<(TU_TYPE)0.0>>, mole>::value);
-           static_assert(std::is_base_of<Coherent_unit<s<(TU_TYPE)0.0>, m<(TU_TYPE)0.0>, kg<(TU_TYPE)0.0>, A<(TU_TYPE)0.0>, K<(TU_TYPE)0.0>, mol<(TU_TYPE)0.0>, cd<(TU_TYPE)1.0>>, candela >::value);
+           static_assert(std::is_base_of<Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>, second>::value);
+           static_assert(std::is_base_of<Coherent_unit<s<std::ratio<0>>, m<std::ratio<1>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>, metre>::value);
+           static_assert(std::is_base_of<Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>, kilogram>::value);
+           static_assert(std::is_base_of<Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>, ampere>::value);
+           static_assert(std::is_base_of<Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<1>>, mol<std::ratio<0>>, cd<std::ratio<0>>>, kelvin>::value);
+           static_assert(std::is_base_of<Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<1>>, cd<std::ratio<0>>>, mole>::value);
+           static_assert(std::is_base_of<Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<1>>>, candela >::value);
          }
   );
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -187,9 +187,12 @@ int main() {
       auto c2 = Coherent_unit_base<std::ratio<1>, std::ratio<2>>(c1);
       t.template assert<std::equal_to<>>(val, c2.base_value , __LINE__);
 
+      auto c3 = Coherent_unit_base<std::ratio<1>, std::ratio<2>>(std::move(c2));
+      t.template assert<std::equal_to<>>(val, c3.base_value , __LINE__);
+
       Unit<prefix::milli, degree_Fahrenheit> f(val);
-      Coherent_unit_base<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>> c3 = Coherent_unit_base(f);
-      t.template assert<near<>>((val * 1.0e-3f - (TU_TYPE)32.0)/1.8f + (TU_TYPE)273.15, c3.base_value , __LINE__);
+      Coherent_unit_base<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>> c4 = Coherent_unit_base(f);
+      t.template assert<near<>>((val * 1.0e-3f - (TU_TYPE)32.0)/1.8f + (TU_TYPE)273.15, c4.base_value , __LINE__);
     }       
   );
 
@@ -231,9 +234,6 @@ int main() {
         TU_TYPE value = (TU_TYPE)5.0f;
         Unit<prefix::no_prefix, second> s(value);
         t.template assert<std::equal_to<>>(s.value, value, __LINE__);
-
-        //SUnit<second> ss(value);
-        //t.template assert<std::equal_to<>>(ss.value, value, __LINE__);
 
         Unit<prefix::no_prefix, second> s2 = value;
         t.template assert<std::equal_to<>>(s2.value, value, __LINE__); 
@@ -580,8 +580,8 @@ int main() {
       t.assert_true(add_res.value == (TU_TYPE)3.0,  __LINE__);
       t.assert_true(add_res.value == (TU_TYPE)3.0,  __LINE__);
     }
+    
   );
 
-    static_assert(tu::hour::base_multiplier == 3600.0f);
     return Test_stats::fail;
 }

--- a/typesafe_units/include/tu/typesafe_units.h
+++ b/typesafe_units/include/tu/typesafe_units.h
@@ -19,7 +19,7 @@ namespace tu {
 
 constexpr TU_TYPE PI = std::numbers::pi_v<TU_TYPE>;
 
-//namespace internal {
+namespace internal {
 
 template <typename T>
 struct is_ratio : std::false_type {};
@@ -61,7 +61,7 @@ struct Multiply {
   }
 };
 
-//} // namespace internal 
+} // namespace internal 
 
 //
 // Prefixes used to define units.
@@ -216,43 +216,43 @@ struct Base_unit {
 // 
 // Struct representation of base unit s (second) with rational power p
 // 
-template<Ratio p>
+template<internal::Ratio p>
 struct s : internal::Base_unit<p>{};
 
 // 
 // Struct representation of base unit m (metre) with rational power p
 // 
-template<Ratio p>
+template<internal::Ratio p>
 struct m : internal::Base_unit<p>{};
 
 // 
 // Struct representation of base unit kg (kilogram) with rational power p
 // 
-template<Ratio p>
+template<internal::Ratio p>
 struct kg : internal::Base_unit<p>{};
 
 // 
 // Struct representation of base unit A (ampere) with rational power p
 // 
-template<Ratio p>
+template<internal::Ratio p>
 struct A : internal::Base_unit<p>{};
 
 // 
 // Struct representation of base unit K (kelvin) with rational power p
 // 
-template<Ratio p>
+template<internal::Ratio p>
 struct K : internal::Base_unit<p>{};
 
 // 
 // Struct representation of base unit mol (mole) with rational power p
 // 
-template<Ratio p>
+template<internal::Ratio p>
 struct mol : internal::Base_unit<p>{};
 
 // 
 // Struct representation of base unit cd (candela) with rational power p
 // 
-template<Ratio p>
+template<internal::Ratio p>
 struct cd : internal::Base_unit<p>{};
 
 // 
@@ -387,29 +387,29 @@ constexpr auto binary_op_args(internal::Coherent_unit_base<lf, l_args...>, inter
 }
 } // namespace internal
 
-template<Ratio L_first,
-         Ratio... L_args,
-         Ratio R_first,
-         Ratio... R_args>
+template<internal::Ratio L_first,
+         internal::Ratio... L_args,
+         internal::Ratio R_first,
+         internal::Ratio... R_args>
 requires (sizeof...(L_args) == sizeof...(R_args))
 auto operator * (internal::Coherent_unit_base<L_first, L_args...> l,
                  internal::Coherent_unit_base<R_first, R_args...> r) noexcept -> decltype(internal::binary_op_args(internal::Coherent_unit_base<L_first, L_args...>(),
                                                                                                                    internal::Coherent_unit_base<R_first, R_args...>(),
                                                                                                                    internal::Coherent_unit_base<>(),
-                                                                                                                   Plus())) {
+                                                                                                                   internal::Plus())) {
   return {l.base_value * r.base_value}; 
 }
 
-template<Ratio L_first,
-         Ratio... L_args,
-         Ratio R_first,
-         Ratio... R_args>
+template<internal::Ratio L_first,
+         internal::Ratio... L_args,
+         internal::Ratio R_first,
+         internal::Ratio... R_args>
 requires (sizeof...(L_args) == sizeof...(R_args))
 auto operator / (internal::Coherent_unit_base<L_first, L_args...> l,
                  internal::Coherent_unit_base<R_first, R_args...> r) noexcept -> decltype(internal::binary_op_args(internal::Coherent_unit_base<L_first, L_args...>(),
                                                                                                                    internal::Coherent_unit_base<R_first, R_args...>(),
                                                                                                                    internal::Coherent_unit_base<>(),
-                                                                                                                   Minus())) {
+                                                                                                                   internal::Minus())) {
   return {l.base_value / r.base_value}; 
 }
 
@@ -436,14 +436,14 @@ constexpr auto binary_op_args_num(internal::Coherent_unit_base<U_first, U_args..
 // Use the `binary_op_args_num` template functions to perform pow<std::ratio<>>(U<std::Ratio<>...>).
 // Binary operation is Multiply. 
 //
-template<Ratio exp,
-         Ratio U_first,
-         Ratio... U_args>
+template<internal::Ratio exp,
+         internal::Ratio U_first,
+         internal::Ratio... U_args>
 auto pow(internal::Coherent_unit_base<U_first, U_args...> u) noexcept -> decltype(binary_op_args_num(internal::Coherent_unit_base<U_first, U_args...>(),
                                                                                                      exp(),
                                                                                                      internal::Coherent_unit_base<>(),
-                                                                                                     Multiply())) {
-  return {std::pow(u.base_value, fraction(exp()))};
+                                                                                                     internal::Multiply())) {
+  return {std::pow(u.base_value, internal::fraction(exp()))};
 }
 
 //

--- a/typesafe_units/include/tu/typesafe_units.h
+++ b/typesafe_units/include/tu/typesafe_units.h
@@ -182,7 +182,6 @@ struct Coherent_unit_base : Unit_fundament {
   using Base = Coherent_unit_base<p...>;
   constexpr Coherent_unit_base() noexcept = default;
   Coherent_unit_base(TU_TYPE v) noexcept : base_value(v){}
-  Coherent_unit_base(const Coherent_unit_base<p...>& u) noexcept : base_value(u.base_value) {}
   
   template<prefix pf,
            typename U,

--- a/typesafe_units/include/tu/typesafe_units.h
+++ b/typesafe_units/include/tu/typesafe_units.h
@@ -64,7 +64,7 @@ struct Multiply {
 } // namespace internal 
 
 //
-// Prefixes used to define units.
+// Prefixes used to define Units.
 //
 enum struct prefix {
   quecto = -30,
@@ -484,47 +484,47 @@ auto unop(const U& u){
 // 
 // Explicit definitions of coherent units.
 // 
-struct second : Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct metre : Coherent_unit<s<std::ratio<0>>, m<std::ratio<1>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct kilogram: Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct ampere: Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct kelvin: Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<1>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct mole: Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<1>>, cd<std::ratio<0>>>{};
-struct candela: Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<1>>>{};
+using second = Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using metre = Coherent_unit<s<std::ratio<0>>, m<std::ratio<1>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using kilogram = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using ampere = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using kelvin = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<1>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using mole = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<1>>, cd<std::ratio<0>>>;
+using candela = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<1>>>;
 
 //
 // Derived units with special names
 //
-struct scalar : Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct hertz : Coherent_unit<s<std::ratio<-1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct becquerel: Coherent_unit<s<std::ratio<-1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct ohm: Coherent_unit<s<std::ratio<-3>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<-2>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct siemens: Coherent_unit<s<std::ratio<3>>, m<std::ratio<-2>>, kg<std::ratio<-1>>, A<std::ratio<2>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct farad: Coherent_unit<s<std::ratio<4>>, m<std::ratio<-2>>, kg<std::ratio<-1>>, A<std::ratio<2>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct lumen: Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<1>>>{};
-struct weber: Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<-1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct gray: Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct sievert: Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct watt: Coherent_unit<s<std::ratio<-3>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct newton: Coherent_unit<s<std::ratio<-2>>, m<std::ratio<1>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct lux: Coherent_unit<s<std::ratio<0>>, m<std::ratio<-2>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<1>>>{};
-struct radian: Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct joule: Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct steradian: Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct katal: Coherent_unit<s<std::ratio<-1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<1>>, cd<std::ratio<0>>>{};
-struct pascal: Coherent_unit<s<std::ratio<-2>>, m<std::ratio<-1>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct coulomb: Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct henry: Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<-2>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct tesla: Coherent_unit<s<std::ratio<-2>>, m<std::ratio<0>>, kg<std::ratio<1>>, A<std::ratio<-1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct volt : Coherent_unit<s<std::ratio<-3>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<-1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
+using scalar = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using hertz = Coherent_unit<s<std::ratio<-1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using becquerel = Coherent_unit<s<std::ratio<-1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using ohm = Coherent_unit<s<std::ratio<-3>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<-2>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using siemens = Coherent_unit<s<std::ratio<3>>, m<std::ratio<-2>>, kg<std::ratio<-1>>, A<std::ratio<2>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using farad = Coherent_unit<s<std::ratio<4>>, m<std::ratio<-2>>, kg<std::ratio<-1>>, A<std::ratio<2>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using lumen = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<1>>>;
+using weber = Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<-1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using gray = Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using sievert = Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using watt = Coherent_unit<s<std::ratio<-3>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using newton = Coherent_unit<s<std::ratio<-2>>, m<std::ratio<1>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using lux = Coherent_unit<s<std::ratio<0>>, m<std::ratio<-2>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<1>>>;
+using radian = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using joule = Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using steradian = Coherent_unit<s<std::ratio<0>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using katal = Coherent_unit<s<std::ratio<-1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<1>>, cd<std::ratio<0>>>;
+using pascal = Coherent_unit<s<std::ratio<-2>>, m<std::ratio<-1>>, kg<std::ratio<1>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using coulomb = Coherent_unit<s<std::ratio<1>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using henry = Coherent_unit<s<std::ratio<-2>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<-2>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using tesla = Coherent_unit<s<std::ratio<-2>>, m<std::ratio<0>>, kg<std::ratio<1>>, A<std::ratio<-1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using volt = Coherent_unit<s<std::ratio<-3>>, m<std::ratio<2>>, kg<std::ratio<1>>, A<std::ratio<-1>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
 
 //
 // Derived coherent units
 //
-struct metre_per_second : Coherent_unit<s<std::ratio<-1>>, m<std::ratio<1>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct second_squared : Coherent_unit<s<std::ratio<2>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct metre_cubed: Coherent_unit<s<std::ratio<0>>, m<std::ratio<3>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
-struct metre_squared: Coherent_unit<s<std::ratio<0>>, m<std::ratio<2>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>{};
+using metre_per_second = Coherent_unit<s<std::ratio<-1>>, m<std::ratio<1>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using second_squared = Coherent_unit<s<std::ratio<2>>, m<std::ratio<0>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using metre_cubed = Coherent_unit<s<std::ratio<0>>, m<std::ratio<3>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
+using metre_squared = Coherent_unit<s<std::ratio<0>>, m<std::ratio<2>>, kg<std::ratio<0>>, A<std::ratio<0>>, K<std::ratio<0>>, mol<std::ratio<0>>, cd<std::ratio<0>>>;
 
 //
 // Define non coherent units
@@ -534,91 +534,54 @@ struct metre_squared: Coherent_unit<s<std::ratio<0>>, m<std::ratio<2>>, kg<std::
 // Time
 //
 
-struct minute : Non_coherent_unit<(TU_TYPE)60.0, (TU_TYPE)0.0, second> {
-  using Non_coherent_unit<(TU_TYPE)60.0, (TU_TYPE)0.0, second>::Base;
-};
-
-struct hour : Non_coherent_unit<(TU_TYPE)60.0, (TU_TYPE)0.0, minute> {
-  using Non_coherent_unit<(TU_TYPE)60.0, (TU_TYPE)0.0, minute>::Base;
-};
-
-struct day : Non_coherent_unit<(TU_TYPE)24.0, (TU_TYPE)0.0, hour> {
-  using Non_coherent_unit<(TU_TYPE)24.0, (TU_TYPE)0.0, hour>::Base;
-};
+using minute = Non_coherent_unit<(TU_TYPE)60.0, (TU_TYPE)0.0, second>; 
+using hour = Non_coherent_unit<(TU_TYPE)60.0, (TU_TYPE)0.0, minute>;
+using day = Non_coherent_unit<(TU_TYPE)24.0, (TU_TYPE)0.0, hour>;
 
 //
 // Temperature
 //
 
-struct degree_Celsius : Non_coherent_unit<(TU_TYPE)1.0, (TU_TYPE)273.15, kelvin> {
-  using Non_coherent_unit<(TU_TYPE)1.0, (TU_TYPE)273.15, kelvin>::Base;
-};
+using degree_Celsius = Non_coherent_unit<(TU_TYPE)1.0, (TU_TYPE)273.15, kelvin>;
 
 //
 // Mass
 //
 
-struct gram : Non_coherent_unit<(TU_TYPE)0.001, (TU_TYPE)0.0, kilogram> {
-  using Non_coherent_unit<(TU_TYPE)0.001, (TU_TYPE)0.0, kilogram>::Base;
-};
-
-struct tonne : Non_coherent_unit<(TU_TYPE)1000.0, (TU_TYPE)0.0, kilogram> {
-  using Non_coherent_unit<(TU_TYPE)1000.0, (TU_TYPE)0.0, kilogram>::Base;
-};
-
-struct dalton : Non_coherent_unit<(TU_TYPE)1.66053904020e-27, (TU_TYPE)0.0, kilogram> {
-  using Non_coherent_unit<(TU_TYPE)1.66053904020e-27, (TU_TYPE)0.0, kilogram>::Base;
-};
-
-struct unified_atomic_mass_unit : Non_coherent_unit<(TU_TYPE)1.66053904020e-27, (TU_TYPE)0.0, kilogram> {
-  using Non_coherent_unit<(TU_TYPE)1.66053904020e-27, (TU_TYPE)0.0, kilogram>::Base;
-};
+using gram = Non_coherent_unit<(TU_TYPE)0.001, (TU_TYPE)0.0, kilogram>;
+using tonne = Non_coherent_unit<(TU_TYPE)1000.0, (TU_TYPE)0.0, kilogram>;
+using dalton = Non_coherent_unit<(TU_TYPE)1.66053904020e-27, (TU_TYPE)0.0, kilogram>;
+using unified_atomic_mass_unit = Non_coherent_unit<(TU_TYPE)1.66053904020e-27, (TU_TYPE)0.0, kilogram>;
 
 //
 // Energy
 //
 
-struct electronvolt : Non_coherent_unit<(TU_TYPE)1.602176634e-19, (TU_TYPE)0.0, joule> {
-  using Non_coherent_unit<(TU_TYPE)1.602176634e-19, (TU_TYPE)0.0, joule>::Base;
-};
+using electronvolt = Non_coherent_unit<(TU_TYPE)1.602176634e-19, (TU_TYPE)0.0, joule>;
 
 //
 // Volume
 //
 
-struct litre : Non_coherent_unit<(TU_TYPE)0.001, (TU_TYPE)0.0, metre_cubed> {
-  using Non_coherent_unit<(TU_TYPE)0.001, (TU_TYPE)0.0, metre_cubed>::Base;
-};
+using litre = Non_coherent_unit<(TU_TYPE)0.001, (TU_TYPE)0.0, metre_cubed>;
 
 //
 // Plane- and phase angel
 //
 
-struct degree : Non_coherent_unit<(TU_TYPE)(PI/180.0), (TU_TYPE)0.0, radian> {
-  using Non_coherent_unit<(TU_TYPE)(PI/180.0), (TU_TYPE)0.0, radian>::Base;
-};
-
-struct arc_minute : Non_coherent_unit<(TU_TYPE)(1/60.0), (TU_TYPE)0.0, degree> {
-  using Non_coherent_unit<(TU_TYPE)(1/60.0), (TU_TYPE)0.0, degree>::Base;
-};
-
-struct arc_second : Non_coherent_unit<(TU_TYPE)(1/60.0), (TU_TYPE)0.0, arc_minute> {
-  using Non_coherent_unit<(TU_TYPE)(1/60.0), (TU_TYPE)0.0, arc_minute>::Base;
-};
+using degree = Non_coherent_unit<(TU_TYPE)(PI/180.0), (TU_TYPE)0.0, radian>;
+using arc_minute = Non_coherent_unit<(TU_TYPE)(1/60.0), (TU_TYPE)0.0, degree>;
+using arc_second = Non_coherent_unit<(TU_TYPE)(1/60.0), (TU_TYPE)0.0, arc_minute>;
 
 //
 // Area
 //
 
-struct hectare : Non_coherent_unit<(TU_TYPE)(10000.0), (TU_TYPE)0.0, metre_squared> {
-  using Non_coherent_unit<(TU_TYPE)(10000.0), (TU_TYPE)0.0, metre_squared>::Base;
-};
+using hectare = Non_coherent_unit<(TU_TYPE)(10000.0), (TU_TYPE)0.0, metre_squared>;
 
 //
 // Length
 //
 
-struct astronomical_unit : Non_coherent_unit<(TU_TYPE)149597870700.0, (TU_TYPE)0.0, metre> {
-  using Non_coherent_unit<(TU_TYPE)149597870700.0, (TU_TYPE)0.0, metre>::Base;
-};
+using astronomical_unit = Non_coherent_unit<(TU_TYPE)149597870700.0, (TU_TYPE)0.0, metre>;
 } // namespace tu


### PR DESCRIPTION
Fundamental change to how the library works. Now, as in so many other units libraries, only powers of rational numbers are allowed on units.